### PR TITLE
Disable Video Recording Link on Safari

### DIFF
--- a/public/js/pages/choose-method.js
+++ b/public/js/pages/choose-method.js
@@ -1,0 +1,8 @@
+const videoButton = document.getElementById('videoButton');
+const isUsingSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification));
+
+if (isUsingSafari) {
+    alert('Video recording on safari is not supported.');
+    videoButton.href = '#';
+    videoButton.classList.add('disabled');
+}

--- a/resources/views/pages/capture/choose-method.blade.php
+++ b/resources/views/pages/capture/choose-method.blade.php
@@ -9,10 +9,14 @@
                 <h1 class="display-4">How would you like to capture your thoughts?</h1>
                 <div class="text-center">
                     <a href="{{ route('capture-audio') }}?voice={{ $_GET['voice'] ?? '' }}" class="btn btn-primary btn-wide mr-5 btn-lg">Audio</a>
-                    <a href="{{ route('capture-video') }}?voice={{ $_GET['voice'] ?? '' }}" class="btn btn-primary btn-wide btn-lg">Video</a>
+                    <a id="videoButton" href="{{ route('capture-video') }}?voice={{ $_GET['voice'] ?? '' }}" class="btn btn-primary btn-wide btn-lg">Video</a>
                 </div>
             </div>
         </div>
     </div>
 
+@endsection
+
+@section('scripts')
+    <script src="{{ asset('js/pages/choose-method.js') }}?time={{ time() }}"></script>
 @endsection


### PR DESCRIPTION
- When Safari users go to the ```choose-method``` screen, they will be alerted that video recording is not available and the 'video' button will be disabled