### PR TITLE
Prevent Footer from 'floating' on Safari

### DIFF
--- a/public/css/style.bundle.css
+++ b/public/css/style.bundle.css
@@ -15545,7 +15545,7 @@ html {
 
 html,
 body {
-  height: 100%;
+  min-height: 100%;
   margin: 0px;
   padding: 0px;
   font-size: 13px;


### PR DESCRIPTION
I think the issue here was that the ```body```'s height was being calculated as the height of the window by Safari but it was being calculated as the height of the parent html tag by other browsers.

Note: I don't have the hardware to test this on Safari for iOS, is anyone able to test is out for me?