### PR TITLE
Review Recording Modal Update

### DIFF
--- a/public/js/pages/capture-audio.js
+++ b/public/js/pages/capture-audio.js
@@ -135,6 +135,9 @@ function createDownloadLink(blob) {
     });
 
     recordingsList.appendChild(li);
-    $("#myModal").modal();
+    $("#reviewRecordingModal").modal({
+        backdrop: 'static',
+        keyboard: false
+    });
 }
 

--- a/public/js/pages/capture-upload.js
+++ b/public/js/pages/capture-upload.js
@@ -3,8 +3,11 @@ let uploadInfo = document.getElementById('uploadInfo');
 uploadInfo.addEventListener("click", swapModals);
 
 function swapModals() {
-    $("#myModal").modal('hide');
-    $("#uploadModal").modal();
+    $("#reviewRecordingModal").modal('hide');
+    $("#uploadModal").modal({
+        backdrop: 'static',
+        keyboard: false
+    });
 }
 
 function uploadButtonClicked(file, filename){

--- a/public/js/pages/capture-video.js
+++ b/public/js/pages/capture-video.js
@@ -106,7 +106,10 @@ function stopRecording() {
     isRecording = false;
     button.classList.remove('recording');
     button.innerHTML = camIcon;
-    $("#myModal").modal();
+    $("#reviewRecordingModal").modal({
+        backdrop: 'static',
+        keyboard: false
+    });
     if ( navigator.vibrate ) navigator.vibrate( [ 200, 100, 200 ] );
     const chunks = [];
     preview.classList.add('d-none');

--- a/resources/views/pages/capture/capture-audio.blade.php
+++ b/resources/views/pages/capture/capture-audio.blade.php
@@ -22,7 +22,7 @@
                     </div>
                     
                     <!-- Modal -->
-                    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                    <div class="modal fade" id="reviewRecordingModal" tabindex="-1" role="dialog" aria-labelledby="reviewRecordingModal" aria-hidden="true">
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">

--- a/resources/views/pages/capture/capture-video.blade.php
+++ b/resources/views/pages/capture/capture-video.blade.php
@@ -50,11 +50,14 @@
                 </div>
 
                 <!-- Modal -->
-                <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal fade" id="reviewRecordingModal" tabindex="-1" role="dialog" aria-labelledby="reviewRecordingModal" aria-hidden="true">
                     <div class="modal-dialog" role="document">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title" id="exampleModalLabel">Review Recording</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
                             </div>
                             <div class="modal-body">
                                 <div id="recordingsList">


### PR DESCRIPTION
- Fixes #56 
- Renames ```myModal``` to ```reviewRecordingModal``` for clarity
- Prevents clicks outside modal from closing modal
- Adds little x in the top right corner of modal